### PR TITLE
[merged] Support 'with', 'without' keys

### DIFF
--- a/rdgo/basetask_resolve.py
+++ b/rdgo/basetask_resolve.py
@@ -80,7 +80,8 @@ class BaseTaskResolve(Task):
 
     def _expand_component(self, component):
         for key in component:
-            if key not in ['src', 'spec', 'distgit', 'tag', 'branch', 'freeze', 'self-buildrequires']:
+            if key not in ['src', 'spec', 'distgit', 'tag', 'branch', 'freeze', 'self-buildrequires',
+                           'rpmwith', 'rpmwithout']:
                 fatal("Unknown key {0} in component: {1}".format(key, component))
         # 'src' and 'distgit' mappings
         src = component.get('src')
@@ -138,6 +139,10 @@ class BaseTaskResolve(Task):
         for key in distgit:
             if key not in ['patches', 'src', 'name', 'tag', 'branch', 'freeze']:
                 fatal("Unknown key {0} in component/distgit: {1}".format(key, component))
+
+        # rpmbuild --with and --without
+        self._ensure_key_or(component, 'rpmwith', [])
+        self._ensure_key_or(component, 'rpmwithout', [])
 
         self._ensure_key_or(component, 'pkgname', pkgname_default)
 

--- a/rdgo/task_build.py
+++ b/rdgo/task_build.py
@@ -28,7 +28,7 @@ from .swappeddir import SwappedDirectory
 from .utils import log, fatal, rmrf, ensure_clean_dir, run_sync
 from .task import Task
 from .git import GitMirror
-from .mockchain import MockChain
+from .mockchain import MockChain, SRPMBuild
 
 def require_key(conf, key):
     try:
@@ -182,7 +182,8 @@ class TaskBuild(Task):
             srcsnap = component['srcsnap']
             newcache[distgit_name] = {'hashv0': component_hash,
                                       'dirname': srcsnap.replace('.srcsnap','')}
-            pkglist.append(self.snapshotdir + '/' + srcsnap + '/')
+            pkglist.append(SRPMBuild(self.snapshotdir + '/' + srcsnap + '/',
+                                     component['rpmwith'], component['rpmwithout']))
             needed_builds.add(distgit_name)
             need_createrepo = True
 


### PR DESCRIPTION
These ultimately filter down to `rpmbuild --with|out`.  The rationale
for this is that for some components I actually want to make
use of this, even though it's not traditional in Fedora/CentOS.

For example, rpm-ostree can be built with/without bundled libhif, and
for rdgo I want to not bundle.