### PR TITLE
[merged] Add a 'srpmroot' key, used to inject SRPM root dependencies

### DIFF
--- a/rdgo/basetask_resolve.py
+++ b/rdgo/basetask_resolve.py
@@ -81,7 +81,7 @@ class BaseTaskResolve(Task):
     def _expand_component(self, component):
         for key in component:
             if key not in ['src', 'spec', 'distgit', 'tag', 'branch', 'freeze', 'self-buildrequires',
-                           'rpmwith', 'rpmwithout']:
+                           'rpmwith', 'rpmwithout', 'srpmroot']:
                 fatal("Unknown key {0} in component: {1}".format(key, component))
         # 'src' and 'distgit' mappings
         src = component.get('src')


### PR DESCRIPTION
I'm trying to build a newer golang from Fedora dist-git for CentOS
Atomic Host Continuous, but hitting an issue where it's relying on the
implicit `redhat-rpm-config` -> `go-srpm-macros` in Fedora, which
doesn't exist in CentOS.

We can work around that by specially denoting RPMs which contain
macros, and ensuring they end up in the buildroot.  This is cleaner
than defining our own `foo-rpm-config` package.