### PR TITLE
[merged] build: Copy logs to logdir rather than move

### DIFF
--- a/rdgo/task_build.py
+++ b/rdgo/task_build.py
@@ -84,7 +84,7 @@ class TaskBuild(Task):
                 for subname in os.listdir(buildpath):
                     subpath = buildpath + '/' + subname
                     if subname.endswith(('.json', '.log')):
-                        shutil.move(subpath, sublogdir + '/' + subname)
+                        shutil.copy(subpath, sublogdir + '/' + subname)
             if not success:
                 del newcache[distgit_name]
             else:


### PR DESCRIPTION
This way they get retained with the lifecycle of the builds.  The
--logdir was intended for Jenkins.

Closes: #34