### PR TITLE
spec: Update %global commit

### DIFF
--- a/rdgo/specfile.py
+++ b/rdgo/specfile.py
@@ -117,6 +117,11 @@ class Spec(object):
         if n == 0:
             self._txt = tag + ':' + value + '\n' + self._txt
 
+    def set_global(self, k, value):
+        self._txt, n = re.subn(r'^(%%global\s+%s\s*) ([a-f0-9]+)' % (k,),
+                               r'\1 %s' % value, self.txt, flags=re.M)
+        print("{} -> {} subs: {}".format(k, value, n))
+
     def get_patches_base(self, expand_macros=False):
         """Return a tuple (version, number_of_commits) that are parsed
         from the patches_base in the specfile.

--- a/rdgo/task_resolve.py
+++ b/rdgo/task_resolve.py
@@ -104,6 +104,7 @@ class TaskResolve(BaseTaskResolve):
             if has_zero:
                 source_tag += '0'
             spec.set_tag(source_tag, tarname)
+            spec.set_global('commit', upstream_rev)
             spec.set_tag('Version', rpm_version)
             spec.set_setup_dirname(tar_dirname)
             spec.set_tag('Release', rpm_release + '%{?dist}')


### PR DESCRIPTION
This is a common pattern, and we need it in case the specfile references it.