### PR TITLE
build: Add srpm data to logdir

### DIFF
--- a/rdgo/task_build.py
+++ b/rdgo/task_build.py
@@ -83,8 +83,11 @@ class TaskBuild(Task):
                 ensure_clean_dir(sublogdir)
                 for subname in os.listdir(buildpath):
                     subpath = buildpath + '/' + subname
+                    destpath = sublogdir + '/' + subname
                     if subname.endswith(('.json', '.log')):
-                        shutil.copy(subpath, sublogdir + '/' + subname)
+                        shutil.copy(subpath, destpath)
+                    elif subname == 'srpm':
+                        shutil.copytree(subpath, destpath)
             if not success:
                 del newcache[distgit_name]
             else:


### PR DESCRIPTION
Hitting an issue that appears to be down to missing `go-srpm-macros` data
which is used when the SRPM is generated.  Let's be sure we gather the
data related to the build of the SRPM into logdir too so it's available
in Jenkins or equivalent.